### PR TITLE
Support NFS defaults on Solaris.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -3,9 +3,11 @@ version '1.0.0'
 source 'git://github.com/ghoneycutt/puppet-module-types.git'
 author 'ghoneycutt'
 license 'Apache License, Version 2.0'
-summary 'put a summary here'
-description 'put a description here'
+summary 'Puppet module to manage default types through hashes in Hiera'
+description "Puppet module to manage default types through hashes in Hiera with the
+create_resources() function. This module adds validation and helper functions,
+such as ensuring directories. Without specifying any hashes, this module will take no action."
 project_page 'https://github.com/ghoneycutt/puppet-module-types'
 
-dependency 'puppetlabs/stdlib', '3.2.x'
+dependency 'puppetlabs/stdlib', '>= 3.2.0'
 dependency 'ghoneycutt/common', '>= 1.0.2'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ Hash of resource type `mount`.
 
 ## `types::mount`
 
-Besides ensuring the mount resource, will also ensure that the directory for the mount exists.
+Besides ensuring the mount resource, will also ensure that the directory for
+the mount exists.
+
+If `options` parameter is passed and it is set to 'defaults' on osfamily
+Solaris, it will use '-' as the mount option instead of 'defaults', as
+'defaults' is not supported on Solaris.
 
 ### Parameters required or with defaults
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -23,6 +23,15 @@ define types::mount (
   include common
   common::mkdir_p { $name: }
 
+  # Solaris cannot handle 'defaults' as a mount option. A common use case would
+  # be to have NFS exports specified in Hiera for multiple systems and if the
+  # system is Solaris, it would throw an error.
+  if $options == 'defaults' and $::osfamily == 'Solaris' {
+    $options_real = '-'
+  } else {
+    $options_real = $options
+  }
+
   mount { $name:
     ensure      => $ensure,
     name        => $name,
@@ -31,7 +40,7 @@ define types::mount (
     device      => $device,
     dump        => $dump,
     fstype      => $fstype,
-    options     => $options,
+    options     => $options_real,
     pass        => $pass,
     provider    => $provider,
     remounts    => $remounts,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 describe 'types' do
 
+  it { should compile.with_all_deps }
+
   context 'with default options' do
-    it { should include_class('types') }
+    it { should contain_class('types') }
   end
 
   context 'with mounts specified as a hash' do
@@ -23,7 +25,7 @@ describe 'types' do
       }
     } } }
 
-    it { should include_class('types') }
+    it { should contain_class('types') }
 
     it {
       should contain_mount('/mnt').with({
@@ -67,7 +69,7 @@ describe 'types' do
 
     it 'should fail' do
       expect {
-        should include_class('types')
+        should contain_class('types')
       }.to raise_error(Puppet::Error)
     end
   end

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-
 describe 'types::mount' do
+
   context 'mount with bare minimum specified' do
     let(:title) { '/mnt' }
     let(:params) do
@@ -67,8 +67,50 @@ describe 'types::mount' do
 
     it 'should fail' do
       expect {
-        should include_class('types')
+        should contain_class('types')
       }.to raise_error(Puppet::Error,/types::mount::invalid::ensure is invalid and does not match the regex./)
+    end
+  end
+
+  describe 'with \'options\' parameter set to \'defaults\'' do
+    context 'on osfamily Solaris' do
+      let(:title) { '/mnt' }
+      let(:params) do
+        { :device      => '/dev/fiction',
+          :fstype      => 'iso9660',
+          :options     => 'defaults',
+        }
+      end
+      let(:facts) { { :osfamily => 'Solaris' } }
+
+      it {
+        should contain_mount('/mnt').with({
+          'ensure'      => 'mounted',
+          'device'      => '/dev/fiction',
+          'fstype'      => 'iso9660',
+          'options'     => '-',
+        })
+      }
+    end
+
+    context 'on osfamily that is not Solaris' do
+      let(:title) { '/mnt' }
+      let(:params) do
+        { :device      => '/dev/fiction',
+          :fstype      => 'iso9660',
+          :options     => 'defaults',
+        }
+      end
+      let(:facts) { { :osfamily => 'Debian' } }
+
+      it {
+        should contain_mount('/mnt').with({
+          'ensure'      => 'mounted',
+          'device'      => '/dev/fiction',
+          'fstype'      => 'iso9660',
+          'options'     => 'defaults',
+        })
+      }
     end
   end
 end


### PR DESCRIPTION
If `options` parameter is passed and it is set to 'defaults' on osfamily
Solaris, it will use '-' as the mount option instead of 'defaults', as
'defaults' is not supported on Solaris.
